### PR TITLE
Added a fallback for repo connection and branch configuration

### DIFF
--- a/src/helpers/appCenterUrlBuilder.ts
+++ b/src/helpers/appCenterUrlBuilder.ts
@@ -22,6 +22,10 @@ export class AppCenterUrlBuilder {
         return `${SettingsHelper.getAppCenterPortalEndpoint()}/users/${appOwner}/apps/${appName}/build/branches/${branchName}/setup`;
     }
 
+    public static GetPortalConnectRepoLink(appOwner: string, appName: string): string {
+        return `${SettingsHelper.getAppCenterPortalEndpoint()}/users/${appOwner}/apps/${appName}/build/connect`;
+    }
+
     public static GetPortalCrashesLink(appOwner: string, appName: string): string {
         return `${SettingsHelper.getAppCenterPortalEndpoint()}/users/${appOwner}/apps/${appName}/crashes/`;
     }

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -99,6 +99,8 @@ export class Strings {
     public static ReleasingUpdateContentsMessage: string = "Sending update to CodePush...";
     public static ReactNativeInstallHint: string = "Make sure you ran \"npm install\" and that you are inside a React Native project.";
     public static CodePushInstallHint: string = "Make sure you ran \"npm install\" and that you are inside a React Native Code Push project.";
+    public static RepoManualConnectBtnLabel: string = "Connect";
+    public static BuildManualConfigureBtnLabel: string = "Configure build";
 
     public static CreatingAppStatusBarMessage: string = `Creating a new App Center app...`;
     public static FailedToCreateAppInAppCenter: string = `An error occurred while creating the new App Center app`;
@@ -110,6 +112,14 @@ export class Strings {
     public static SimulateCrashesSendMessage: string = "Sending crash data to App Center...";
     public static CrashesSimulated: string = "The crash has been successfully generated and sent to App Center!";
     public static CrashesSimulatedHint: string = "Check it out";
+
+    public static RepoManualConnectMessage(appName: string): string {
+        return `Could not connect ${appName} to the repository. Please try to do it manually.`;
+    }
+
+    public static BuildManualConfigureMessage(appName: string): string {
+        return `Could not configure ${appName} build. Please try to do it manually.`;
+    }
 
     public static FailedToExecuteLoginMsg(provider: AuthProvider): string {
         return `Failed to login to ${provider}`;


### PR DESCRIPTION
Now if repo connection fails, user is prompted to connect repo manually (given a link).
If configuring build fails, user is prompted to configure it manually (with a link, too).