### PR TITLE
CodePush Release (ReactNative) leaves development flag set

### DIFF
--- a/package.json
+++ b/package.json
@@ -273,6 +273,11 @@
                     "description": "Relative path to a folder that will be included in CodePush releases for this project",
                     "type": "string",
                     "default": ""
+                },
+                "appcenter.codePushRNBundleDevFlag": {
+                    "description": "If false, warnings are disabled and the bundle is minified",
+                    "type": "boolean",
+                    "default": true
                 }
             }
         }

--- a/src/codepush/codepush-sdk/src/react-native/react-native-utils.ts
+++ b/src/codepush/codepush-sdk/src/react-native/react-native-utils.ts
@@ -16,6 +16,7 @@ const properties = require("properties");
 const childProcess = require("child_process");
 import * as fileUtils from "../utils/file-utils";
 import { isValidVersion } from "../utils/validation-utils";
+import { SettingsHelper } from "../../../../helpers/settingsHelper";
 
 export let spawn = childProcess.spawn;
 
@@ -359,6 +360,8 @@ export async function makeUpdateContents(bundleConfig: BundleConfig): Promise<st
 
   fileUtils.createEmptyTmpReleaseFolder(updateContentsPath);
   fileUtils.removeReactTmpDir();
+
+  bundleConfig.development = SettingsHelper.codePushRNBundelDevFlag();
   await runReactNativeBundleCommand(bundleConfig.projectRootPath, bundleConfig.bundleName, bundleConfig.development, bundleConfig.entryFilePath, updateContentsPath, bundleConfig.os, bundleConfig.sourcemapOutput);
 
   return updateContentsPath;

--- a/src/helpers/settingsHelper.ts
+++ b/src/helpers/settingsHelper.ts
@@ -190,4 +190,13 @@ export class SettingsHelper {
         }
         return null;
     }
+
+    public static codePushRNBundelDevFlag(): boolean {
+        const workspaceConfiguration = vscode.workspace.getConfiguration();
+        if (workspaceConfiguration.has("appcenter.codePushRNBundleDevFlag")) {
+            const codePushRNBundelDevFlag: boolean = ConfigurationReader.readBoolean(workspaceConfiguration.get("appcenter.codePushRNBundleDevFlag"));
+            return codePushRNBundelDevFlag;
+        }
+        return true;
+    }
 }


### PR DESCRIPTION
Moved this option to extension settings. 
Is true by default.